### PR TITLE
refactor: Dependabot should keep Eslint & @Eslint/js packages in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,8 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    vitest-packages:
+      patterns:
+        - "eslint"
+        - "@eslint/js"


### PR DESCRIPTION
This PR ensures Dependabot submits 1 PR when `eslint` & `@eslint/js` release new versions.

It is recommended to keep these 2 packages in sync.